### PR TITLE
feat: Add bcc support to trace runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 GIT_ORG ?= iovisor
 
 IMAGE_NAME_INIT ?= quay.io/$(GIT_ORG)/kubectl-trace-init
-IMAGE_NAME ?= quay.io/$(GIT_ORG)/kubectl-trace-bpftrace
+IMAGE_NAME ?= quay.io/$(GIT_ORG)/kubectl-trace-runner
 
 IMAGE_TRACERUNNER_BRANCH := $(IMAGE_NAME):$(GIT_BRANCH_CLEAN)
 IMAGE_TRACERUNNER_COMMIT := $(IMAGE_NAME):$(GIT_COMMIT)

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ IMAGE_INITCONTAINER_LATEST := $(IMAGE_NAME_INIT):latest
 IMAGE_BUILD_FLAGS ?= "--no-cache"
 
 BPFTRACEVERSION ?= "v0.11.1"
+BCCVERSION ?= "v0.16.0-focal-release"
 
 LDFLAGS := -ldflags '-X github.com/iovisor/kubectl-trace/pkg/version.buildTime=$(shell date +%s) -X github.com/iovisor/kubectl-trace/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageName=${IMAGE_NAME} -X github.com/iovisor/kubectl-trace/pkg/cmd.ImageTag=${GIT_COMMIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageName=${IMAGE_NAME_INIT} -X github.com/iovisor/kubectl-trace/pkg/cmd.InitImageTag=${GIT_COMMIT}'
 TESTPACKAGES := $(shell go list ./... | grep -v github.com/iovisor/kubectl-trace/integration)
@@ -70,6 +71,7 @@ image/build:
 	$(DOCKER) build \
 		--build-arg bpftraceversion=$(BPFTRACEVERSION) \
 		--build-arg GIT_ORG=$(GIT_ORG) \
+		--build-arg bccversion=$(BCCVERSION) \
 		$(IMAGE_BUILD_FLAGS) \
 		-t "$(IMAGE_TRACERUNNER_BRANCH)" \
 		-f build/Dockerfile.tracerunner .

--- a/build/Dockerfile.tracerunner
+++ b/build/Dockerfile.tracerunner
@@ -1,5 +1,7 @@
 ARG bpftraceversion=v0.11.1
+ARG bccversion=v0.16.0-focal-release
 FROM quay.io/iovisor/bpftrace:$bpftraceversion as bpftrace
+FROM quay.io/iovisor/bcc:$bccversion as bcc
 
 FROM golang:1.15-buster as gobuilder
 ARG GIT_ORG=iovisor
@@ -16,6 +18,11 @@ FROM ubuntu:20.04
 
 RUN apt-get update
 RUN apt-get install -y xz-utils
+
+# Install bcc by copying apt packages from docker image
+COPY --from=bcc /root/bcc /tmp/bcc
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python python3 binutils libelf1 kmod && \
+  dpkg -i /tmp/bcc/*.deb && rm -rf /tmp/bcc
 
 COPY --from=gobuilder /go/src/github.com/iovisor/kubectl-trace/_output/bin/trace-runner /bin/trace-runner
 COPY --from=bpftrace /usr/bin/bpftrace /usr/bin/bpftrace

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -89,6 +89,7 @@ type RunOptions struct {
 	tracer         string
 	selector       string
 	program        string
+	programArgs    string
 	tracerDefined  bool
 	parsedSelector *tracejob.Selector
 
@@ -152,6 +153,7 @@ func NewRunCommand(factory cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().StringVar(&o.tracer, "tracer", "bpftrace", "Tracing system to use")
 	cmd.Flags().StringVar(&o.selector, "selector", "", "Selector (label query) to filter on")
 	cmd.Flags().StringVar(&o.program, "program", o.program, "Program to execute")
+	cmd.Flags().StringVar(&o.programArgs, "program-args", o.programArgs, "Additional arguments to pass on to program (semicolon separated)")
 
 	// global flags
 	cmd.Flags().BoolVarP(&o.attach, "attach", "a", o.attach, "Whether or not to attach to the trace program once it is created")
@@ -372,6 +374,7 @@ func (o *RunOptions) Run() error {
 		Selector:            o.parsedSelector.String(),
 		Output:              "stdout",
 		Program:             o.program,
+		ProgramArgs:         o.programArgs,
 		ImageNameTag:        o.imageName,
 		InitImageNameTag:    o.initImageName,
 		FetchHeaders:        o.fetchHeaders,

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	// ImageName represents the default tracerunner image
-	ImageName = "quay.io/iovisor/kubectl-trace-bpftrace"
+	ImageName = "quay.io/iovisor/kubectl-trace-latest"
 	// ImageTag represents the tag to fetch for ImageName
 	ImageTag = "latest"
 	// InitImageName represents the default init container image

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -89,7 +89,7 @@ type RunOptions struct {
 	tracer         string
 	selector       string
 	program        string
-	programArgs    string
+	programArgs    []string
 	tracerDefined  bool
 	parsedSelector *tracejob.Selector
 
@@ -153,7 +153,7 @@ func NewRunCommand(factory cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().StringVar(&o.tracer, "tracer", "bpftrace", "Tracing system to use")
 	cmd.Flags().StringVar(&o.selector, "selector", "", "Selector (label query) to filter on")
 	cmd.Flags().StringVar(&o.program, "program", o.program, "Program to execute")
-	cmd.Flags().StringVar(&o.programArgs, "program-args", o.programArgs, "Additional arguments to pass on to program (semicolon separated)")
+	cmd.Flags().StringArrayVar(&o.programArgs, "args", o.programArgs, "Additional arguments to pass on to program, repeat flag for multiple arguments")
 
 	// global flags
 	cmd.Flags().BoolVarP(&o.attach, "attach", "a", o.attach, "Whether or not to attach to the trace program once it is created")

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -188,12 +188,6 @@ func (o *TraceRunnerOptions) prepBpfTraceCommand() (*string, *string, error) {
 		if err != nil {
 			return nil, nil, err
 		}
-		if pid == nil {
-			return nil, nil, fmt.Errorf("pid not found")
-		}
-		if len(*pid) == 0 {
-			return nil, nil, fmt.Errorf("invalid pid found")
-		}
 		f, err := ioutil.ReadFile(programPath)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/cmd/tracerunner.go
+++ b/pkg/cmd/tracerunner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -16,12 +15,44 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	bpftrace = "bpftrace"
+	bcc      = "bcc"
+)
+
+var (
+	bpfTraceBinaryPath = "/usr/bin/bpftrace"
+)
+
 type TraceRunnerOptions struct {
-	podUID             string
-	containerName      string
-	inPod              bool
-	programPath        string
-	bpftraceBinaryPath string
+	// The tracing system to use.
+	// tracer = bpftrace | bcc | perf
+	tracer string
+
+	// Selector (label query) that identifies entity to be traced.
+	// selector = label '=' value [',' labelN '=' valueN ...]
+	// Currently supported labels:
+	// - node
+	//   Select a node by name
+	// - pod
+	//   Select a pod by name
+	// - pod-uid
+	//   Select a pod by UID
+	// - container
+	//   Select a container by name
+	selector string
+
+	// Where will the tracing system send output.
+	// output = stdout | file:///path | URI
+	output string
+
+	// In the case of bcc the name of the bcc program to execute.
+	// In the case of bpftrace the path to contents of the user provided expression or program.
+	program string
+
+	// In the case of bcc the user provided arguments to pass on to program.
+	// Not used for bpftrace.
+	programArgs string
 }
 
 func NewTraceRunnerOptions() *TraceRunnerOptions {
@@ -46,19 +77,28 @@ func NewTraceRunnerCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&o.containerName, "container", "c", o.containerName, "Specify the container")
-	cmd.Flags().StringVarP(&o.podUID, "poduid", "p", o.podUID, "Specify the pod UID")
-	cmd.Flags().StringVarP(&o.programPath, "program", "f", "program.bt", "Specify the bpftrace program path")
-	cmd.Flags().StringVarP(&o.bpftraceBinaryPath, "bpftracebinary", "b", "/bin/bpftrace", "Specify the bpftrace binary path")
-	cmd.Flags().BoolVar(&o.inPod, "inpod", false, "Whether or not run this bpftrace in a pod's container process namespace")
+	cmd.Flags().StringVar(&o.tracer, "tracer", "bpftrace", "Tracing system to use")
+	cmd.Flags().StringVar(&o.selector, "selector", "", "Selector (label query) to filter on")
+	cmd.Flags().StringVar(&o.output, "output", "stdout", "Where will the tracing system send output")
+	cmd.Flags().StringVar(&o.program, "program", "/programs/program.bt", "Tracer input script or executable")
+	cmd.Flags().StringVar(&o.programArgs, "program-args", o.programArgs, "Arguments to pass through to executable in --program")
 	return cmd
 }
 
 func (o *TraceRunnerOptions) Validate(cmd *cobra.Command, args []string) error {
-	// TODO(fntlnz): do some more meaningful validation here, for now just checking if they are there
-	if o.inPod == true && (len(o.containerName) == 0 || len(o.podUID) == 0) {
-		return fmt.Errorf("poduid and container must be specified when inpod=true")
+	switch o.tracer {
+	case bpftrace, bcc:
+	default:
+		return fmt.Errorf("unknown tracer %s", o.tracer)
 	}
+
+	switch o.output {
+	case "stdout":
+	default:
+		return fmt.Errorf("unknown output %s", o.output)
+	}
+
+	// TODO(zqureshi): parse and validate selector.
 	return nil
 }
 
@@ -68,28 +108,20 @@ func (o *TraceRunnerOptions) Complete(cmd *cobra.Command, args []string) error {
 }
 
 func (o *TraceRunnerOptions) Run() error {
-	programPath := o.programPath
-	if o.inPod == true {
-		pid, err := findPidByPodContainer(o.podUID, o.containerName)
-		if err != nil {
-			return err
-		}
-		if pid == nil {
-			return fmt.Errorf("pid not found")
-		}
-		if len(*pid) == 0 {
-			return fmt.Errorf("invalid pid found")
-		}
-		f, err := ioutil.ReadFile(programPath)
-		if err != nil {
-			return err
-		}
-		programPath = path.Join(os.TempDir(), "program-container.bt")
-		r := strings.Replace(string(f), "$container_pid", *pid, -1)
-		if err := ioutil.WriteFile(programPath, []byte(r), 0755); err != nil {
-			return err
-		}
+	var err error
+	var binary, args *string
+	switch o.tracer {
+	case bpftrace:
+		binary, args, err = o.prepBpfTraceCommand()
+	case bcc:
+		binary, args, err = o.prepBccCommand()
 	}
+
+	if err != nil {
+		return err
+	}
+
+	// Assume output is stdout until other backends are implemented.
 
 	fmt.Println("if your program has maps to print, send a SIGINT using Ctrl-C, if you want to interrupt the execution send SIGINT two times")
 	ctx, cancel := context.WithCancel(context.Background())
@@ -116,11 +148,51 @@ func (o *TraceRunnerOptions) Run() error {
 		}
 	}()
 
-	c := exec.CommandContext(ctx, o.bpftraceBinaryPath, programPath)
+	var c *exec.Cmd
+	if args == nil || len(*args) == 0 {
+		c = exec.CommandContext(ctx, *binary)
+	} else {
+		c = exec.CommandContext(ctx, *binary, *args)
+	}
+
 	c.Stdout = os.Stdout
 	c.Stdin = os.Stdin
 	c.Stderr = os.Stderr
 	return c.Run()
+}
+
+func (o *TraceRunnerOptions) prepBpfTraceCommand() (*string, *string, error) {
+	programPath := o.program
+
+	// TODO(zqureshi): Filter using selector.
+	// Render $container_pid to actual process pid if scoped to container.
+	// if o.target == "container" {
+	// 	pid, err := findPidByPodContainer(o.podUID, o.containerName)
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// 	if pid == nil {
+	// 		return nil, nil, fmt.Errorf("pid not found")
+	// 	}
+	// 	if len(*pid) == 0 {
+	// 		return nil, nil, fmt.Errorf("invalid pid found")
+	// 	}
+	// 	f, err := ioutil.ReadFile(programPath)
+	// 	if err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// 	programPath = path.Join(os.TempDir(), "program-container.bt")
+	// 	r := strings.Replace(string(f), "$container_pid", *pid, -1)
+	// 	if err := ioutil.WriteFile(programPath, []byte(r), 0755); err != nil {
+	// 		return nil, nil, err
+	// 	}
+	// }
+
+	return &bpfTraceBinaryPath, &programPath, nil
+}
+
+func (o *TraceRunnerOptions) prepBccCommand() (*string, *string, error) {
+	return nil, nil, fmt.Errorf("tracer bcc not implemented")
 }
 
 func findPidByPodContainer(podUID, containerName string) (*string, error) {

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -34,7 +34,7 @@ type TraceJob struct {
 	Selector            string
 	Output              string
 	Program             string
-	ProgramArgs         string
+	ProgramArgs         []string
 	ImageNameTag        string
 	InitImageNameTag    string
 	FetchHeaders        bool
@@ -206,8 +206,8 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 		traceCmd = append(traceCmd, "--program="+nj.Program)
 	}
 
-	if len(nj.ProgramArgs) > 0 {
-		traceCmd = append(traceCmd, "--program-args="+nj.ProgramArgs)
+	for _, arg := range nj.ProgramArgs {
+		traceCmd = append(traceCmd, "--args="+arg)
 	}
 
 	commonMeta := metav1.ObjectMeta{

--- a/pkg/tracejob/job.go
+++ b/pkg/tracejob/job.go
@@ -34,6 +34,7 @@ type TraceJob struct {
 	Selector            string
 	Output              string
 	Program             string
+	ProgramArgs         string
 	ImageNameTag        string
 	InitImageNameTag    string
 	FetchHeaders        bool
@@ -203,6 +204,10 @@ func (t *TraceJobClient) CreateJob(nj TraceJob) (*batchv1.Job, error) {
 		traceCmd = append(traceCmd, "--program=/programs/program.bt")
 	} else {
 		traceCmd = append(traceCmd, "--program="+nj.Program)
+	}
+
+	if len(nj.ProgramArgs) > 0 {
+		traceCmd = append(traceCmd, "--program-args="+nj.ProgramArgs)
 	}
 
 	commonMeta := metav1.ObjectMeta{

--- a/pkg/tracejob/selector.go
+++ b/pkg/tracejob/selector.go
@@ -19,6 +19,11 @@ func NewSelector(query string) (*Selector, error) {
 		terms: map[string]string{},
 	}
 
+	query = strings.TrimSpace(query)
+	if len(query) == 0 {
+		return s, nil
+	}
+
 	terms := strings.Split(query, ",")
 	for _, t := range terms {
 		seg := strings.Split(t, "=")

--- a/pkg/tracejob/selector.go
+++ b/pkg/tracejob/selector.go
@@ -1,0 +1,72 @@
+package tracejob
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Selector represents a label query to select the entity to be traced.
+// Most commonly this entity would resolve into a host, pod or container.
+type Selector struct {
+	// label -> value, values cannot contain spaces.
+	// Assumes equality match, will be changed when more operators added.
+	terms map[string]string
+}
+
+// NewSelector will construct a selector by parsing the query.
+func NewSelector(query string) (*Selector, error) {
+	s := &Selector{
+		terms: map[string]string{},
+	}
+
+	terms := strings.Split(query, ",")
+	for _, t := range terms {
+		seg := strings.Split(t, "=")
+		if len(seg) != 2 {
+			return nil, fmt.Errorf("invalid term in selector at %s", t)
+		}
+
+		label, value := strings.TrimSpace(seg[0]), strings.TrimSpace(seg[1])
+		s.terms[label] = value
+	}
+
+	return s, nil
+}
+
+// Get a label by name.
+func (s *Selector) Get(label string) (string, bool) {
+	value, ok := s.terms[label]
+	return value, ok
+}
+
+// Set a label by name.
+// Returns the value just set.
+func (s *Selector) Set(label, value string) string {
+	s.terms[label] = value
+	return value
+}
+
+// String converts selector back to a query.
+func (s *Selector) String() string {
+	terms := []string{}
+	for k, v := range s.terms {
+		terms = append(terms, k+"="+v)
+	}
+	return strings.Join(terms, ",")
+}
+
+func (s *Selector) Node() (string, bool) {
+	return s.Get("node")
+}
+
+func (s *Selector) Pod() (string, bool) {
+	return s.Get("pod")
+}
+
+func (s *Selector) PodUID() (string, bool) {
+	return s.Get("pod-uid")
+}
+
+func (s *Selector) Container() (string, bool) {
+	return s.Get("container")
+}

--- a/pkg/tracejob/selector_test.go
+++ b/pkg/tracejob/selector_test.go
@@ -1,0 +1,61 @@
+package tracejob
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	. "github.com/go-check/check"
+)
+
+type SelectorSuite struct{}
+
+func init() {
+	Suite(&SelectorSuite{})
+}
+
+func Test(t *testing.T) { TestingT(t) }
+
+// sorted will output a query like selector.String() but with terms in order.
+func sorted(s *Selector) string {
+	terms := sort.StringSlice{}
+	for k, v := range s.terms {
+		terms = append(terms, k+"="+v)
+	}
+	terms.Sort()
+	return strings.Join(terms, ",")
+}
+
+func (s *SelectorSuite) TestNewSlice(c *C) {
+	parsed, err := NewSelector("foo=bar, abc=xyz")
+	c.Assert(err, IsNil)
+	c.Assert(sorted(parsed), Equals, "abc=xyz,foo=bar")
+}
+
+func (s *SelectorSuite) TestNewSliceError(c *C) {
+	// Would do a table test if more than 3 cases.
+	_, err := NewSelector("pod=hello-world node=minikube")
+	c.Assert(err, NotNil)
+
+	_, err = NewSelector("pod=hello-world,, node=minikube")
+	c.Assert(err, NotNil)
+}
+
+func (s *SelectorSuite) TestString(c *C) {
+	expected := &Selector{
+		terms: map[string]string{
+			"foo": "bar",
+			"abc": "xyz",
+		},
+	}
+
+	parsed, _ := NewSelector("foo=bar, abc=xyz")
+	c.Assert(parsed, DeepEquals, expected)
+}
+
+func (s *SelectorSuite) TestNode(c *C) {
+	parsed, _ := NewSelector("pod=hello-world, node=minikube")
+	val, ok := parsed.Node()
+	c.Assert(ok, Equals, true)
+	c.Assert(val, Equals, "minikube")
+}


### PR DESCRIPTION
This PR takes the work done by @adelbertc (thanks!) in #117 and reworks it on top of #136. This change introduces a new cli flag `--args` that can be repeated to provide a list of arguments, apply variable substitution and then pass on to the bcc tool.

Example usage
```bash
$ kubectl trace run \
  --fetch-headers \
  --attach \
  --tracer='bcc' \
  --selector='pod=hello-world-f678b5744-tfl4j' \
  --program='tcplife' \
  --args='-t' \
  --args='-p $container_pid' \
  --args='-L 8080'
```

~There is some discussion on slack around the `--program-args` field and I agree that is a pretty ugly and non-user-friendly choice. A better mechanism would be to use positional args and pass through everything after the standard shell `--` separator. I did not make that change because it would have been a backwards incompatible change but if we can come to an agreement I'll make it so.~

I have updated the PR to use repeated invocations of `--args` instead of a semicolon separated string, but we should still consider whether a breaking change and then taking everything after `--` would be a better option.

Co-authored-by: Adelbert Chang <achang@octoml.ai>